### PR TITLE
Disable auto branch deletion and adopt long-lived topic branches

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to GuildBankLedger will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Changed
+- Repository workflow: disabled auto branch deletion on merge and adopted long-lived per-area topic branches (`ui`, `sync`, `accessibility`, `layout-sort`) for recurring maintainer work. Short-lived `chore/*`, `infra/*`, `hotfix/*` branches still cover one-off and cross-cutting changes. Documented in the new `CLAUDE.md` Branch Workflow section and reflected in `CONTRIBUTING.md`. No addon behavior change.
+
 ## [0.30.2] - 2026-04-27
 
 ### Added

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,42 @@ luacheck .                 # lint production code
 - Saved variables: `GuildBankLedgerDB` (AceDB), data keyed per guild name
 - **Sync is guild-wide** — all members participate in HELLO/sync, not just officers. Officer rank only gates UI visibility (settings, admin features). Never add rank checks to the sync protocol.
 
+## Branch Workflow
+
+`main` is the integration target and is GitHub-protected (PR + `test-and-lint` CI required, merge commits only, force-push and deletion blocked). Auto branch deletion on merge is **off**, so topic branches survive their PRs and can be reused.
+
+### Topic branches (long-lived, per area)
+
+Recurring areas of work live on long-lived branches that accumulate multiple commits and PR to `main` as periodic checkpoints, similar to how an area-owning team would batch updates. Initial set:
+
+- `ui` for UI/*.lua (except UI/Accessibility.lua)
+- `sync` for Sync.lua, Fingerprint.lua, sync diagnostics, audit plumbing
+- `accessibility` for UI/Accessibility.lua and palette / font / keyboard work
+- `layout-sort` for BankLayout.lua, SortPlanner.lua, SortExecutor.lua, UI/LayoutEditor.lua, UI/SortView.lua
+
+Create a topic branch the first time work in that area appears, not preemptively. Add new topic branches when a fifth recurring area emerges.
+
+### Short-lived branches (one-off, off main)
+
+Cross-cutting work, infra changes, and one-off refactors still use short-lived branches off `main`:
+
+- `chore/<thing>` for maintainer chores, repo-config changes, doc-only updates
+- `infra/<thing>` for CI / build / tooling changes
+- `hotfix/<thing>` for urgent production-impact fixes (see Hotfix rule below)
+
+These branches **do** get deleted after merge (manually, via `git push origin --delete <branch>` or the GitHub UI button). Auto-delete is off so deletion is intentional, not implicit.
+
+### Rules
+
+- **Hotfix rule**: an urgent production-impact fix never goes on a topic branch. Open `hotfix/<thing>` off `main`, PR it, merge, then rebase any affected topic branches onto the new `main`.
+- **Cross-area rule**: when one feature spans two topic branches (e.g. a sync change that needs a UI tab), merge the upstream-of-the-dependency branch first, rebase the dependent branch onto the new `main`, then commit the dependent piece. Never PR both branches simultaneously hoping git resolves the order.
+- **Two-PR-from-same-topic rule**: a topic branch can only have one open PR at a time. If `ui` has a ready batch and unrelated WIP, checkpoint-PR the ready batch first, then continue WIP after the merge + rebase. Splitting WIP off to a temporary `ui-<thing>` is a fallback when the WIP must continue in parallel.
+- **Rebase cadence**: rebase each touched topic branch onto `origin/main` at the start of every working session in that area, and immediately after every merge. `git rebase origin/main` if conflicts are tame; fall back to `git merge origin/main` if not. Push back with `git push --force-with-lease` (allowed on topic branches since they are unprotected).
+- **CHANGELOG conflict policy**: a topic branch stamps its target version header (e.g. `## [0.31.0] - <pending>`) only when opening the PR, not during ongoing work. If two branches PR with the same target version, the second to merge rebases onto post-merge `main` and bumps to the next patch. The `[Unreleased]` block is fine for the lead branch but typically gets stamped on PR-open.
+- **CI cadence**: `.github/workflows/ci.yml` runs on `pull_request` and `push: main` only. Intermediate commits on a topic branch are unverified by CI. Run `bash run_tests.sh` and `bash run_tests.sh --lint` locally before each commit so topic branches stay green.
+- **Stale-branch policy**: if a topic branch has had no commits for 3 months, delete it and recreate fresh from `main` when work resumes. Long-lived does not mean immortal.
+- **Carve-out from the global "small, focused PRs" rule**: the user's global `~/.claude/CLAUDE.md` "Open Source / Public Repo Workflow" section says "Keep PRs small and focused, one concern per PR." That rule is for external-contributor PRs. For the maintainer's own topic-branch PRs in this repo, multiple related commits per PR is the intended pattern. External contributor PRs still follow the small-and-focused rule.
+
 ## Sync subsystem notes
 
 ### Protocol / transport

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,6 +41,8 @@ GuildBankLedger is a Lua 5.1 WoW addon tested with [busted](https://lunarmodules
 
 `main` is protected: direct pushes are blocked, merge is gated on CI, and the only merge style is a merge commit (so your commits are preserved on `main` with your authorship).
 
+**Maintainer note**: the repo uses long-lived per-area topic branches (`ui`, `sync`, `accessibility`, `layout-sort`) for recurring work, alongside short-lived `chore/*`, `infra/*`, and `hotfix/*` branches for one-off changes. See the **Branch Workflow** section in [CLAUDE.md](CLAUDE.md) for the full set of rules (rebase cadence, hotfix path, cross-area sequencing, CHANGELOG conflict policy). External contributors don't need to think about this; just branch from `main` and open a PR as described above.
+
 ## Commit message format
 
 - **Subject line**: imperative, concise, ≤72 chars. If you bumped versions, suffix with `(vX.Y.Z)`.
@@ -119,7 +121,7 @@ These come up in ~every sync / bank interaction PR:
 2. CI runs (`busted` + `luacheck`). Iterate until green.
 3. The maintainer will review. For most PRs this is a day or two, faster for small fixes.
 4. On approval, the maintainer merges with a merge commit (your commits stay intact on `main` with your authorship). If you're not bumping versions / CHANGELOG, a follow-up bookkeeping commit handles that.
-5. The feature branch auto-deletes on merge (for branches in this repo; forks are untouched).
+5. External contributor branches (forks) are untouched on merge. Short-lived maintainer branches (`chore/*`, `infra/*`, `hotfix/*`) can be deleted manually after merge. The long-lived topic branches (`ui`, `sync`, `accessibility`, `layout-sort`) are kept on the remote and reused across sessions, so they are not deleted on merge.
 
 Maintainer note: if CI is flaky in a way that cannot be fixed inside the PR (e.g., GitHub Actions outage), the `main-protection` ruleset can be temporarily disabled from **Settings → Rules → Rulesets**. Re-enable immediately after.
 


### PR DESCRIPTION
## Summary

Switches the repo workflow from one-shot per-feature branches to long-lived per-area topic branches (`ui`, `sync`, `accessibility`, `layout-sort`) for recurring maintainer work, alongside short-lived `chore/*`, `infra/*`, and `hotfix/*` branches for one-off changes. Auto branch deletion on merge is turned **off** so topic branches survive their PRs and can be reused across sessions.

Why: features keep returning to the same areas (sync iteration v0.28.x → v0.30.2, repeated UI polish, layout/sort milestones) and a fresh narrow branch every time loses continuity. Long-lived topic branches let related commits accumulate and PR to `main` as periodic checkpoints, similar to how an area-owning team would batch updates.

## Testing

- [x] `bash run_tests.sh` — 995 successes / 0 failures
- [x] `bash run_tests.sh --lint` — 0 warnings / 0 errors in 22 files
- [x] `gh repo view --json deleteBranchOnMerge` returns `{"deleteBranchOnMerge":false}` (flipped via `gh api -X PATCH` before the docs commit)

This is a docs + repo-config change with zero addon behavior change. CI (`test-and-lint`) should pass trivially.

## Files changed

- `CLAUDE.md` — new Branch Workflow section after Conventions covering topic branches, hotfix / cross-area / two-PR / rebase / CHANGELOG / CI / stale-branch rules, and the carve-out from the global "small focused PRs" rule
- `CONTRIBUTING.md` — maintainer note added under Development workflow pointing at the new section, and the auto-delete sentence in Pull request review process rewritten to reflect the new branch-lifetime model
- `CHANGELOG.md` — `[Unreleased]` block at the top with a Changed entry for the workflow change

## Decisions

- **No version bump.** This is a maintainer-only meta change. By analogy with the global "CI/build config changes... unless they affect how users build or test" carve-out. CHANGELOG entry still required per the global "every commit gets a changelog entry" rule.
- **`UI/ChangelogView.lua` `CHANGELOG_DATA` not updated.** The in-game changelog is for user-visible addon content; this is a maintainer workflow change.
- **PR template untouched.** It doesn't reference branch lifetime or naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)