### PR TITLE
Adopt freeze-after-PR rule for single-purpose branches

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -81,15 +81,17 @@ Recurring areas of work live on long-lived branches that accumulate multiple com
 
 Create a topic branch the first time work in that area appears, not preemptively. Add new topic branches when a fifth recurring area emerges.
 
-### Short-lived branches (one-off, off main)
+### Single-purpose branches (frozen after PR closes)
 
-Cross-cutting work, infra changes, and one-off refactors still use short-lived branches off `main`:
+Cross-cutting work, infra changes, and one-off refactors use single-purpose branches off `main`:
 
 - `chore/<thing>` for maintainer chores, repo-config changes, doc-only updates
 - `infra/<thing>` for CI / build / tooling changes
 - `hotfix/<thing>` for urgent production-impact fixes (see Hotfix rule below)
 
-These branches **do** get deleted after merge (manually, via `git push origin --delete <branch>` or the GitHub UI button). Auto-delete is off so deletion is intentional, not implicit.
+These branches are **frozen** once their PR closes (merged, closed without merge, or declared done by the user). Frozen means no new commits land on the branch; follow-up work goes on a new branch off `main`. Nothing is deleted: the branch and its history are retained both locally and on the remote, and auto-delete-on-merge stays disabled. The user can unfreeze a branch at any point by explicit decision (typically by rebasing onto the current `main` and resuming work). Agents do not unfreeze on their own initiative.
+
+See **Branch lifecycle: frozen vs long-lived** in `~/.claude/CLAUDE.md` for the full taxonomy and the agent-side decision rule.
 
 ### Rules
 


### PR DESCRIPTION
## Summary

Updates the Branch Workflow section of the project CLAUDE.md to match the new global rule in ~/.claude/CLAUDE.md (claude-config v0.12.12).

- Renames "Short-lived branches (one-off, off main)" to "Single-purpose branches (frozen after PR closes)".
- Replaces the closing line that said branches "do get deleted after merge" with the freeze contract: branches are retained locally and on the remote, accept no new commits once their PR closes, and can be unfrozen later by explicit user decision.
- Adds a one-line pointer to the global rule for the full taxonomy and agent-side check.

The freeze model removes the up-front "is this work one-off or the start of an area?" decision. If a single-purpose branch grows into recurring work, the user can promote it later. No work is lost to a mistaken "this is done" call.

## Test plan

- [x] No code change. Repo-internal documentation only.
- [x] No version bump per `feedback_no_bump_for_trivial_docs.md` (CLAUDE.md is repo-internal AI instruction; addon behavior, .toc, README, and user-facing surfaces are untouched).
- [x] No CHANGELOG entry for the same reason.

## Notes

- This branch is itself the first single-purpose branch governed by the new rule. After merge, it will be frozen, not deleted.
- The companion global rule lands separately in the claude-config repo (v0.12.12) which auto-syncs across machines.