### PR TITLE
Sync CONTRIBUTING.md to single-purpose-frozen branch wording

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -41,7 +41,7 @@ GuildBankLedger is a Lua 5.1 WoW addon tested with [busted](https://lunarmodules
 
 `main` is protected: direct pushes are blocked, merge is gated on CI, and the only merge style is a merge commit (so your commits are preserved on `main` with your authorship).
 
-**Maintainer note**: the repo uses long-lived per-area topic branches (`ui`, `sync`, `accessibility`, `layout-sort`) for recurring work, alongside short-lived `chore/*`, `infra/*`, and `hotfix/*` branches for one-off changes. See the **Branch Workflow** section in [CLAUDE.md](CLAUDE.md) for the full set of rules (rebase cadence, hotfix path, cross-area sequencing, CHANGELOG conflict policy). External contributors don't need to think about this; just branch from `main` and open a PR as described above.
+**Maintainer note**: the repo uses long-lived per-area topic branches (`ui`, `sync`, `accessibility`, `layout-sort`) for recurring work, alongside single-purpose `chore/*`, `infra/*`, and `hotfix/*` branches that are frozen once their PR closes (no new commits land on them; follow-up work goes on a new branch off `main`). See the **Branch Workflow** section in [CLAUDE.md](CLAUDE.md) for the full set of rules (rebase cadence, hotfix path, cross-area sequencing, CHANGELOG conflict policy, freeze contract). External contributors don't need to think about this; just branch from `main` and open a PR as described above.
 
 ## Commit message format
 


### PR DESCRIPTION
## Summary

PR #11 (v0.30.4) renamed the short-lived `chore/*` / `infra/*` / `hotfix/*` category to "single-purpose, frozen after PR closes" in CLAUDE.md and replaced the delete-after-merge contract with the freeze contract. CONTRIBUTING.md's maintainer-note paragraph still described the old "short-lived... for one-off changes" model, which is now stale.

This PR updates that one sentence to match the new wording and adds "freeze contract" to the cross-reference list pointing at CLAUDE.md.

## What changed

- `CONTRIBUTING.md` line 44: replaced "short-lived...for one-off changes" with "single-purpose...frozen once their PR closes" plus a one-line summary of the freeze contract

## Versioning

Repo-internal contributor doc, not addon code or user-facing surface. No version bump per `feedback_no_bump_for_trivial_docs.md`. Will roll up under whatever the next versioned release happens to be.

## Test plan

- [x] CI green (test-and-lint passes — no code change)
- [x] CONTRIBUTING.md renders correctly on GitHub
- [x] Cross-reference to "Branch Workflow" section in CLAUDE.md still accurate

🤖 Generated with [Claude Code](https://claude.com/claude-code)