### PR TITLE
Promote CurseForge description to docs/ and add doc-sync CI advisory

### DIFF
--- a/.github/workflows/curseforge-description-sync.yml
+++ b/.github/workflows/curseforge-description-sync.yml
@@ -1,0 +1,53 @@
+name: curseforge-description-sync
+
+on:
+  pull_request:
+
+jobs:
+  description-sync-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Check whether CurseForge description tracks feature-surface changes
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          set -euo pipefail
+
+          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          echo "Changed files in PR:"
+          echo "$changed"
+          echo
+
+          description="docs/CURSEFORGE-DESCRIPTION.md"
+
+          # Feature-surface globs. Matched in bash with case patterns (extglob).
+          shopt -s extglob
+
+          feature_files=()
+          while IFS= read -r f; do
+            [ -z "$f" ] && continue
+            case "$f" in
+              README.md|docs/ROADMAP.md|GuildBankLedger.toc) feature_files+=("$f") ;;
+              src/*.lua|src/**/*.lua) feature_files+=("$f") ;;
+              UI/*.lua|UI/**/*.lua) feature_files+=("$f") ;;
+            esac
+          done <<< "$changed"
+
+          description_changed=false
+          if echo "$changed" | grep -qx "$description"; then
+            description_changed=true
+          fi
+
+          if [ ${#feature_files[@]} -gt 0 ] && [ "$description_changed" = false ]; then
+            joined=$(IFS=,; echo "${feature_files[*]}")
+            echo "::warning file=${description}::Feature-surface files changed (${joined}) without updating CurseForge description. This check is advisory."
+          elif [ ${#feature_files[@]} -gt 0 ] && [ "$description_changed" = true ]; then
+            echo "::notice::CurseForge description updated alongside feature-surface changes."
+          else
+            echo "No feature-surface changes detected; nothing to flag."
+          fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -66,6 +66,7 @@ luacheck .                 # lint production code
 - Guard `Enum.PlayerInteractionType.GuildBanker` existence for Classic compat
 - Saved variables: `GuildBankLedgerDB` (AceDB), data keyed per guild name
 - **Sync is guild-wide** — all members participate in HELLO/sync, not just officers. Officer rank only gates UI visibility (settings, admin features). Never add rank checks to the sync protocol.
+- **Public description sync**: `docs/CURSEFORGE-DESCRIPTION.md` is the source of truth for the CurseForge project page. When user-facing surface changes (slash commands, UI tabs, access control, sync features, planned-feature framing), update it in the same PR. CI emits a `::warning::` annotation on PRs that change feature-surface files (`README.md`, `docs/ROADMAP.md`, `src/**/*.lua`, `UI/**/*.lua`, `GuildBankLedger.toc`) without updating the description; treat it as a checklist prompt, not a blocking gate. Pasting the updated content into the CurseForge web UI is a manual release step until BigWigsMods/packager#187 lands.
 
 ## Branch Workflow
 

--- a/docs/CURSEFORGE-DESCRIPTION.md
+++ b/docs/CURSEFORGE-DESCRIPTION.md
@@ -1,3 +1,5 @@
+<!-- Source of truth for the CurseForge project page description. After edits, paste contents (excluding this comment) into https://www.curseforge.com/wow/addons/guildbankledger > Manage > Description. -->
+
 # **GuildBankLedger** *- Beta*
 
 WoW's guild bank log only keeps 25 entries per tab. In an active guild, that rolls over in minutes. GuildBankLedger saves every transaction before it's gone and syncs the data across your entire guild automatically.
@@ -25,7 +27,9 @@ Every guild member running the addon automatically logs and shares data. No setu
 - **Transactions** — Scrollable, sortable, filterable log of every item movement. Filter by player, item, date range, category, type, or tab. Paginated (100 per page).
 - **Gold Log** — Deposits, withdrawals, repairs, tab purchases with a summary breakdown panel.
 - **Consumption** — Guild-wide overview dashboard: total items and gold in/out/net, top 10 consumers with gold breakdown (click a name to jump to their transactions), top 15 most-used items with 7d/30d/all-time trend columns.
-- **Sync** — Enable/disable sync, online peers with version and directional status (newer/outdated), sync audit trail, GM access control configuration.
+- **Sort** — Preview the planned moves to reshape the bank against a saved layout, then execute one move at a time with throttling, verification, and abort-on-foreign-activity. Rank-gated execute.
+- **Layout** — Per-tab template editor (display, overflow, ignore modes) with per-item slot counts and stack sizes. Capture-from-current-tab shortcut, two-tier access control (Layout Write and Sort-only). Rank-gated write.
+- **Sync** — Enable/disable sync, online peers with version and directional status (newer/outdated), GM access control configuration.
 - **Changelog** — Embedded version history, paginated (10 versions per page).
 - **About** — Addon info, author credit, support links.
 
@@ -51,6 +55,9 @@ Settings sync to all guild members automatically.
 - `/gbl` — Toggle the ledger window
 - `/gbl status` — Version, guild, transaction count, last scan
 - `/gbl scan` — Manual full scan
+- `/gbl synclog` — Pop up the sync session log
+- `/gbl sortlog` — Pop up the sort session log
+- `/gbl logs` — Pop up the master log (sync + sort + system, interleaved by timestamp)
 - `/gbl help` — Show all commands
 
 **Status** — Beta. Recording, sync, and UI are stable and in active guild use. Planned: export (CSV/Discord/BBCode), raid team management, alt linking, stock alerts.


### PR DESCRIPTION
## Summary

- Moves `.claude/curseforge-description.md` to `docs/CURSEFORGE-DESCRIPTION.md` so the public CurseForge description reads as a first-class shipping doc, not agent scratch. Fixes three known-stale items along the way (the removed sync audit panel, the missing Layout and Sort tabs, the new `/gbl synclog` / `/gbl sortlog` / `/gbl logs` commands), and adds an HTML breadcrumb at the top naming the CurseForge web-UI destination so the manual-paste step is self-documenting.
- Adds a `## Conventions` bullet to project `CLAUDE.md` covering the doc-sync rule: when user-facing surface changes (slash commands, UI tabs, access control, sync features, planned-feature framing), update the description in the same PR.
- Adds `.github/workflows/curseforge-description-sync.yml`, a non-blocking workflow that emits a `::warning::` annotation on PRs that change feature-surface files (`README.md`, `docs/ROADMAP.md`, `src/**/*.lua`, `UI/**/*.lua`, `GuildBankLedger.toc`) without touching the description, and a `::notice::` when both change. Advisory only; never fails the job. No `pull-requests: write` permission needed (annotations via stdout).

CurseForge has no public API for description updates and BigWigsMods/packager#187 is still open, so pasting the file content into the CurseForge web UI Manage > Description stays a manual release step.

No version bump per `feedback_no_bump_for_trivial_docs.md`: repo-internal tooling plus content fix without addon-code changes. The next addon-code PR carries the next version tag.

## Test plan

- [ ] `test-and-lint` CI green (busted + luacheck; 1192 tests pass locally, 0 luacheck warnings)
- [ ] `curseforge-description-sync` check appears in PR checks list
- [ ] On this PR: workflow runs green with no annotations (feature-surface files unchanged; expected per plan)
- [ ] Optional negative-path probe: push a one-line whitespace edit to `README.md`, confirm `::warning::` cites `README.md`, revert before merge
- [ ] Optional positive-path probe: combine the README edit with a no-op edit to `docs/CURSEFORGE-DESCRIPTION.md`, confirm `::notice::` fires instead of `::warning::`, revert both before merge
- [ ] Rename detected with `git log --follow docs/CURSEFORGE-DESCRIPTION.md`
- [ ] Post-merge: paste `docs/CURSEFORGE-DESCRIPTION.md` content (excluding the HTML breadcrumb) into the CurseForge project page Manage > Description