### PR TITLE
Surface CurseForge description-sync advisory in PR conversation (fork-PR safe)

### DIFF
--- a/.github/workflows/curseforge-description-sync.yml
+++ b/.github/workflows/curseforge-description-sync.yml
@@ -1,31 +1,55 @@
+# SECURITY: This workflow uses `pull_request_target` to grant `pull-requests: write`
+# permission for posting sticky comments on PRs from forks. The standard
+# `pull_request` event gives fork PRs a read-only GITHUB_TOKEN regardless of the
+# `permissions:` block, which would silently break comment posting.
+#
+# THIS WORKFLOW MUST NEVER:
+# - Check out the PR head ref (`actions/checkout` with `ref: refs/pull/N/head`
+#   or `refs/pull/N/merge`)
+# - Read, source, cat, bash, or otherwise execute content from any file in
+#   the PR diff
+# - Install dependencies, run build scripts, or invoke binaries built from
+#   PR code
+# - Interpolate attacker-controlled `github.event.pull_request.*` fields
+#   (`head_ref`, `title`, `body`, `head.repo.*`) into shell commands
+#
+# The diff is computed via the GitHub REST API on filenames only. No fork
+# code touches the runner. See ~/.claude/projects/.../memory/feedback_curseforge_description_sync.md
+# for the design rationale.
+
 name: curseforge-description-sync
 
 on:
-  pull_request:
+  pull_request_target:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: description-sync-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
 
 jobs:
   description-sync-check:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-
-      - name: Check whether CurseForge description tracks feature-surface changes
+      - name: Compute description-sync state
+        id: diff_check
         env:
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
           set -euo pipefail
 
-          changed=$(git diff --name-only "$BASE_SHA...$HEAD_SHA")
+          changed=$(gh api "repos/${REPO}/pulls/${PR_NUMBER}/files" --paginate -q '.[].filename')
           echo "Changed files in PR:"
           echo "$changed"
           echo
 
           description="docs/CURSEFORGE-DESCRIPTION.md"
 
-          # Feature-surface globs. Matched in bash with case patterns (extglob).
           shopt -s extglob
 
           feature_files=()
@@ -43,11 +67,72 @@ jobs:
             description_changed=true
           fi
 
+          state="none"
           if [ ${#feature_files[@]} -gt 0 ] && [ "$description_changed" = false ]; then
+            state="out_of_sync"
             joined=$(IFS=,; echo "${feature_files[*]}")
             echo "::warning file=${description}::Feature-surface files changed (${joined}) without updating CurseForge description. This check is advisory."
           elif [ ${#feature_files[@]} -gt 0 ] && [ "$description_changed" = true ]; then
-            echo "::notice::CurseForge description updated alongside feature-surface changes."
+            state="in_sync"
+            echo "::notice file=${description}::CurseForge description updated alongside feature-surface changes."
+          elif [ "$description_changed" = true ]; then
+            # Description-only edits (e.g., a manual tweak) still owe the post-merge paste,
+            # so treat as in_sync to fire the reminder.
+            state="in_sync"
+            echo "::notice file=${description}::CurseForge description updated; post-merge paste required."
           else
             echo "No feature-surface changes detected; nothing to flag."
           fi
+
+          echo "state=${state}" >> "$GITHUB_OUTPUT"
+          {
+            echo "triggers_list_markdown<<__GBL_EOF__"
+            if [ ${#feature_files[@]} -gt 0 ]; then
+              for f in "${feature_files[@]}"; do
+                printf -- "- \`%s\`\n" "$f"
+              done
+            fi
+            echo "__GBL_EOF__"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Sticky comment - description may be stale
+        if: steps.diff_check.outputs.state == 'out_of_sync'
+        uses: marocchino/sticky-pull-request-comment@v3
+        continue-on-error: true
+        with:
+          header: curseforge-description-sync
+          message: |
+            **Heads up: the CurseForge description may need updating.**
+
+            This PR changes feature-surface files but does not touch `docs/CURSEFORGE-DESCRIPTION.md`:
+
+            ${{ steps.diff_check.outputs.triggers_list_markdown }}
+
+            If the change alters what a user would learn from reading the CurseForge project page (slash commands, UI tabs, access control, sync features, planned-feature framing, accessibility claims), update `docs/CURSEFORGE-DESCRIPTION.md` in this PR. Otherwise dismiss this comment.
+
+            _This check is advisory and does not block merge. See `feedback_curseforge_description_sync.md` for the rationale._
+
+      - name: Sticky comment - post-merge paste reminder
+        if: steps.diff_check.outputs.state == 'in_sync'
+        uses: marocchino/sticky-pull-request-comment@v3
+        continue-on-error: true
+        with:
+          header: curseforge-description-sync
+          message: |
+            **CurseForge description updated in this PR. Post-merge paste required.**
+
+            `docs/CURSEFORGE-DESCRIPTION.md` was updated. After this PR merges, paste the new contents (excluding the HTML breadcrumb comment at the top of the file) into the CurseForge project page Manage > Description:
+
+            https://www.curseforge.com/wow/addons/guildbankledger > Manage > Description
+
+            There is no API for this. CurseForge has not shipped a description-update endpoint, and `BigWigsMods/packager#187` (the upstream feature request) has not landed. Until one of those changes, the maintainer paste is the only path from `docs/CURSEFORGE-DESCRIPTION.md` to the public CurseForge page.
+
+            _This reminder is the entire reason the workflow exists. Do not dismiss it without performing the paste._
+
+      - name: Sticky comment - delete when not applicable
+        if: steps.diff_check.outputs.state == 'none'
+        uses: marocchino/sticky-pull-request-comment@v3
+        continue-on-error: true
+        with:
+          header: curseforge-description-sync
+          delete: true


### PR DESCRIPTION
## Summary

The `curseforge-description-sync` workflow (shipped in PR #20) emits `::warning::` and `::notice::` annotations, but these are practically invisible from the PR Conversation tab. Reviewers had to click through Actions → workflow run → Annotations to see them. This PR adds a sticky-comment lifecycle on the Conversation tab and tightens the transport so the comment posts correctly on fork PRs as well as same-repo branches.

**Three-state sticky comment** (shared `header: curseforge-description-sync` marker so all three steps update the same physical comment):

- `out_of_sync` → "Heads up: the CurseForge description may need updating" with the list of triggering feature-surface files.
- `in_sync` → "CurseForge description updated in this PR. Post-merge paste required." with the CurseForge web UI URL. This case is the entire reason the workflow exists, since pasting `docs/CURSEFORGE-DESCRIPTION.md` into the CurseForge Manage > Description page is a manual step (no API, `BigWigsMods/packager#187` not landed).
- `none` → comment deleted.

**Trigger moves from `pull_request` to `pull_request_target`** so the workflow's `GITHUB_TOKEN` has `pull-requests: write` on fork PRs (the standard `pull_request` event gives forks read-only token regardless of the workflow's `permissions:` block).

**Diff source moves from `git diff` to `gh api repos/.../pulls/N/files`** via the GitHub REST API. This:
- Sidesteps the `pull_request_target` correctness issue (default checkout doesn't fetch the PR head SHA, so `git diff base...head` would have failed).
- Drops `actions/checkout@v4` entirely; no fork code touches the runner.
- Keeps the existing case-pattern matching for feature-surface globs intact.

**Defensive measures**:
- Top-of-file `SECURITY:` comment block documents what the workflow must never do (check out PR head, read/source/cat fork files, install or execute PR-side code, interpolate attacker-controlled `github.event.pull_request.*` fields into shell). Future-self foot-gun guard.
- `concurrency: { group: per-PR, cancel-in-progress: true }` so two pushes in quick succession don't race on the comment API.
- `continue-on-error: true` on all three sticky steps so a comment-post failure (rate limit, transient 5xx) does not red-X the check. The inline `::warning::` / `::notice::` annotation from the bash step remains as the real safety signal.
- `file=docs/CURSEFORGE-DESCRIPTION.md` added to the notice annotation so it lands inline on Files Changed (previously only the warning had a file ref).
- Multi-line `triggers_list_markdown` emitted via the documented `$GITHUB_OUTPUT` heredoc form.

No version bump per `feedback_no_bump_for_trivial_docs.md`: this only touches `.github/workflows/`, no addon code, no `.toc`, no README.

## Test plan

**Important constraint**: `pull_request_target` runs the workflow file from the **base branch**, not the PR. The new behavior cannot be observed on this PR; its own checks will execute the prior workflow (still using `pull_request` + `git diff`). Real verification has to happen post-merge against a throwaway test PR.

Pre-merge (on this PR):
- [ ] `test-and-lint` CI green (1192 tests pass locally, 0 luacheck warnings; the workflow file isn't in their scope)
- [ ] `description-sync-check` workflow (prior version) runs on this PR. Expected outcome: this PR touches no feature-surface files, just the workflow itself, so state = `none`, no annotation, no comment.
- [ ] Manual review of the workflow file: confirm no `cat`/`source`/`bash`/`actions/checkout` of fork content; confirm only `GH_TOKEN`, `github.repository`, `github.event.pull_request.number` flow into shell.

Post-merge (on a throwaway `chore/description-sync-test-DO-NOT-MERGE` PR):
- [ ] `out_of_sync` test: push a one-line whitespace edit to `README.md`. Expect sticky warning comment with `README.md` listed.
- [ ] `in_sync` transition: add a trailing newline to `docs/CURSEFORGE-DESCRIPTION.md`. Expect the same sticky comment to update in place to the post-merge paste reminder.
- [ ] `none` transition: revert both edits. Expect the sticky comment to disappear.
- [ ] Close the test PR without merging.

Fork-PR verification deferred to the next real fork PR (low traffic; engineering a fork test is high-friction). The inline annotation works without `Approve and run` even for first-time contributors.