### PR TITLE
Hide Sort and Layout tabs from users without sort access

### DIFF
--- a/UI/SortView.lua
+++ b/UI/SortView.lua
@@ -215,7 +215,13 @@ function GBL:_SortView_Preview()
         if not layout or not next(layout.tabs) then
             local lbl = AceGUI:Create("Label")
             lbl:SetFullWidth(true)
-            lbl:SetText("|cffffcc00No bank layout configured. Open the Layout tab to set one up.|r")
+            local msg
+            if self:HasLayoutWrite() then
+                msg = "|cffffcc00No bank layout configured. Open the Layout tab to set one up.|r"
+            else
+                msg = "|cffffcc00No bank layout configured. Ask a guild officer with layout access to set one up.|r"
+            end
+            lbl:SetText(msg)
             content:AddChild(lbl)
             return
         end

--- a/UI/UI.lua
+++ b/UI/UI.lua
@@ -147,10 +147,10 @@ function GBL:RebuildTabs()
             { value = "transactions", text = "Transactions" },
             { value = "goldlog", text = "Gold Log" },
             { value = "consumption", text = "Consumption" },
-            { value = "sort", text = "Sort" },
         }
-        -- Layout editor: only visible to characters with sort access.
+        -- Sort and Layout tabs: only visible to characters with sort access.
         if self.HasSortAccess and self:HasSortAccess() then
+            table.insert(tabs, { value = "sort", text = "Sort" })
             table.insert(tabs, { value = "layout", text = "Layout" })
         end
         table.insert(tabs, { value = "sync", text = "Sync" })


### PR DESCRIPTION
## Summary

- Sort and Layout tabs are now both gated on `HasSortAccess()` — previously the Sort tab was visible to all guild members even though only sort-access users could do anything useful with it
- Users without sort access were shown a message directing them to a Layout tab they couldn't see; that message is now only shown to users who actually have the Layout tab available
- For sort-only users (sort access but no layout write), the no-layout message now says to ask an officer rather than implying they can set one up themselves

## Test plan

- [x] Log in as a character without sort access — Sort and Layout tabs should not appear
- [ ] Log in as a sort-only character (in the sort tier, not write tier) — Sort and Layout tabs appear; with no layout configured, message reads "Ask a guild officer with layout access to set one up"
- [ ] Log in as a layout-write character — Sort and Layout tabs appear; with no layout configured, message reads "Open the Layout tab to set one up"

🤖 Generated with [Claude Code](https://claude.com/claude-code)