### PR TITLE
Give the money-type normalization a verdict, and pin it at the builder

### DIFF
--- a/docs/DATA-MODEL.md
+++ b/docs/DATA-MODEL.md
@@ -222,6 +222,79 @@ Two consequences of the current prefix that are worth knowing:
   cannot grow through sync. And #75 repairs the sync-received records that lost `itemID` as part of its
   own sweep. Neither touches these 108, which were all scanned locally.
 
+### One identity namespace, two arrays
+
+Records live in two arrays but identity is pooled. `seenTxHashes` (`src/Dedup.lua:127-130`),
+`eventCounts` (`src/Dedup.lua:405`), the fingerprint accumulator and its buckets
+(`src/Fingerprint.lua:70-76`, `:129-145`) and the `idIndex` that `HandleSyncData` builds
+(`src/Sync.lua:2129-2135`) all walk `transactions` and `moneyTransactions` into one flat structure
+with no namespace tag. `BuildStoredRecordIndex` (`src/Dedup.lua:219-228`) is the only one that
+takes a `storageKey`, so it is the exception rather than the rule.
+
+Nothing about that pooling is wrong on its own, because `buildPrefix` gives items five pipe fields
+and money three, and a player name cannot contain a pipe. Well-formed item and money ids cannot
+collide. It matters only in combination with the `itemID` fallthrough above: a record that reaches
+the money branch by accident lands in a shared namespace rather than an item-only one.
+
+The reachable consequence is in `NormalizeRecordId` (`src/Sync.lua:2071-2095`), which adopts the
+sender's id for a local record it looks up as `idIndex[matchedKey]` and never checks which array
+that record came from. An incoming item record with no `itemID` that prefix-matches a stored money
+record would overwrite that money record's `id`, `_occurrence` and `timestamp`, and then be counted
+as a duplicate and dropped. One event silently loses its identity and another is discarded.
+**Verdict: closed by #68 rather than here.** Its shape check requires exactly one of `itemID` or
+`amount`, and a record that lost its `itemID` has neither, so it is rejected at intake and never
+reaches this path. Recorded because the hazard is in the receive path, not in #68's stated subject,
+and its test list should cover it.
+
+### The type string is identity, and normalized only on the local path
+
+`type` is the first field of both prefixes. The money log is the one place where the API disagrees
+with itself: `GetGuildBankMoneyTransaction` returns `"withdrawal"` where `GetGuildBankTransaction`
+returns `"withdraw"` for the same user action. `CreateMoneyTxRecord` rewrites it
+(`src/Ledger.lua:133`), before `ComputeTxHash` runs, so `"withdraw"` is what goes into every money
+id ever stored.
+
+**Verdict: correct as it stands, and not cosmetic.** The differing record shapes do not make the
+string cosmetic, because nothing downstream reads the shape before reading the type. Every consumer
+matches the stored string exactly and not one of them accepts both spellings: player stats
+(`src/Ledger.lua:229`, `:238`), daily summaries (`src/Storage.lua:101`, `:111`), six sites in
+`UI/ConsumptionView.lua` (`:92`, `:101`, `:118`, `:192`, `:356`, `:420`), both type dropdowns
+(`UI/UI.lua:623`, `:1441`), and the filter equality test (`UI/FilterBar.lua:105`). An
+un-normalized record therefore contributes 0 to every money total, matches no filter, and is
+deleted at day 30 by compaction with nothing folded into the summary first. That silent zeroing is
+the v0.4.1 bug the normalization fixed, and it is why a spec pins the builder as well as the read
+path (`spec/ledger_spec.lua`).
+
+It also fails accessibility in all three channels at once, which is worth stating separately given
+that triple encoding is a v1.0 gate. `GetTxTypeDisplay` (`UI/Accessibility.lua:218-233`) resolves
+color by comparison, icon by `A11Y.ICONS[txType]` and label by `A11Y.TX_LABELS[txType]`, so an
+unrecognized type falls to `NEUTRAL`, a nil icon and the raw string as its own label. Color, shape
+and text degrade together, which is exactly the failure triple encoding exists to prevent.
+
+Changing any of this is identity affecting. `"withdraw"` is already in every stored money id, so
+un-normalizing would need a migration, a wire-fixture update and a floor raise, and would leave a
+permanent bucket-hash mismatch against un-migrated peers in the meantime: the bucket key is parsed
+from the id's `|<hourSlot>:<occurrence>` suffix (`src/Fingerprint.lua:106-116`), so a type-only
+change moves no record between buckets while changing its hash contribution, and the affected
+bucket re-syncs forever without converging.
+
+Two smaller points follow from the same normalization:
+
+- **It widens the degenerate collision above, but does not cause it.** Before normalization an
+  itemID-less item `withdraw` and a money `withdrawal` differed in their first prefix field.
+  Afterwards they do not. `deposit` was already shared, since both APIs emit it verbatim, so the
+  root cause is the `itemID` fallthrough and not the rewrite.
+- **Sync intake does not normalize.** `reconstructSyncRecord` (`src/Sync.lua:1146-1192`) never
+  inspects the value, and intake checks only that `type` is non-empty (section 8), so a
+  `"withdrawal"` record from a peer would be stored verbatim. No such record exists or can arrive:
+  the census found zero across all 12,310 stored records, no tagged release ever shipped the
+  un-normalized code (the money feature landed in v0.2.0 and the fix in v0.4.1 with no tag between
+  them, the earliest tag in the repo being v0.5.0-alpha), the concurrent money-tab-index bug in the
+  same commit meant money never loaded at all for a guild with fewer than eight tabs, and the exact
+  version match in `HandleHello` rules out a mixed-version peer today. **Verdict: closed by #68's
+  enum check**, which rejects it. Rejection is the right treatment rather than normalizing on
+  intake, because no legitimate sender of that string can exist.
+
 ## 6. Timestamps
 
 `timestamp` is the event time, computed from the relative offsets `GetGuildBankTransaction` returns.
@@ -426,6 +499,8 @@ All under the **Data model integrity** milestone.
 | 3 | Two structures named `peers`, the persisted one write-only | #72 |
 | 4 | No deposit or withdraw record knows its tab | #67 |
 | 5 | Item records with no `itemID` collide in the money branch | #69 (locally scanned, unscheduled), #75 (sync-received) |
+| 5 | `NormalizeRecordId` can rewrite a money record from an item record | #68 |
+| 5 | Sync intake does not normalize the money `type` | #68 |
 | 7 | Nothing stops the `schemaVersion` default being raised | #76 |
 | 8 | Intake accepts corrupted records | #68 |
 | 8 | 223 corrupted records already stored | #75 |

--- a/spec/helpers.lua
+++ b/spec/helpers.lua
@@ -197,7 +197,10 @@ function Helpers.makeTransaction(txType, name, itemLink, count, tab, destTab, ho
 end
 
 --- Create a mock money transaction log entry.
--- @param txType string "deposit"|"withdraw"|"repair"|"buyTab"|"depositSummary"
+-- These values are what the WoW API hands back, not what gets stored. The API
+-- returns "withdrawal" for money where items say "withdraw"; CreateMoneyTxRecord
+-- normalizes it. Pass "withdrawal" here when a test needs the real API string.
+-- @param txType string "deposit"|"withdrawal"|"repair"|"buyTab"|"depositSummary"
 -- @param name string Player name
 -- @param amount number Copper amount
 -- @param hoursAgo number Hours ago the transaction occurred

--- a/spec/ledger_spec.lua
+++ b/spec/ledger_spec.lua
@@ -89,6 +89,26 @@ describe("Ledger", function()
             assert.equals("TestOfficer-TestRealm", rec.scannedBy)
             assert.is_string(rec.id)
         end)
+
+        -- The API returns "withdrawal" for money where items say "withdraw".
+        -- Normalizing at the builder is what lets every downstream consumer
+        -- match one string, and it runs before ComputeTxHash, so the normalized
+        -- form is baked into the record id. Changing either half is identity
+        -- affecting: it rewrites every money id ever stored.
+        it("normalizes 'withdrawal' to 'withdraw' in both type and id", function()
+            local rec = GBL:CreateMoneyTxRecord("withdrawal", "Thrall", 500000, 0, 0, 0, 2)
+
+            assert.equals("withdraw", rec.type)
+            assert.equals("withdraw|Thrall-TestRealm|500000|"
+                .. math.floor((MockWoW.serverTime - 7200) / 3600), rec.id)
+        end)
+
+        it("leaves the other API money types untouched", function()
+            for _, txType in ipairs({ "deposit", "repair", "buyTab", "depositSummary" }) do
+                local rec = GBL:CreateMoneyTxRecord(txType, "Thrall", 1000, 0, 0, 0, 0)
+                assert.equals(txType, rec.type)
+            end
+        end)
     end)
 
     describe("StoreTx", function()

--- a/spec/sync_spec.lua
+++ b/spec/sync_spec.lua
@@ -997,7 +997,7 @@ describe("Sync", function()
             -- Each record ~180 bytes estimated (long strings push size)
             for i = 1, 35 do
                 txList[i] = {
-                    type = "withdrawal",
+                    type = "withdraw",
                     player = "Verylongnamecharacter",
                     itemID = 200000 + i,
                     count = 20,
@@ -1005,7 +1005,7 @@ describe("Sync", function()
                     classID = 0,
                     subclassID = 5,
                     timestamp = 1700000000 + i,
-                    id = "withdrawal|Verylongnamecharacter|" .. (200000 + i)
+                    id = "withdraw|Verylongnamecharacter|" .. (200000 + i)
                         .. "|20|3|472222:" .. i,
                 }
             end
@@ -2605,11 +2605,11 @@ describe("Sync", function()
             -- Fill one full chunk with realistic transaction records
             for i = 1, GBL.SYNC_CHUNK_SIZE do
                 table.insert(guildData.transactions, {
-                    type = "withdrawal", player = "Longnamechar",
+                    type = "withdraw", player = "Longnamechar",
                     itemID = 200000 + i, count = 20, tab = 3,
                     timestamp = 1700000000 + i, scanTime = 1700000000 + i,
-                    scannedBy = "Anotherlongname", id = "withdrawal|Longnamechar|" .. (200000 + i) .. "|20|3|472222:" .. i,
-                    classID = 0, subClassID = 5,
+                    scannedBy = "Anotherlongname", id = "withdraw|Longnamechar|" .. (200000 + i) .. "|20|3|472222:" .. i,
+                    classID = 0, subclassID = 5,
                     category = "Trade Goods: Cloth",
                 })
             end
@@ -8313,8 +8313,8 @@ describe("Sync", function()
                 },
                 moneyTransactions = {
                     -- epoch-0 id money record
-                    { type = "withdrawal", player = "P2", amount = 500,
-                      id = "withdrawal|P2|500|0:0", timestamp = 0, scannedBy = "Me-Realm" },
+                    { type = "withdraw", player = "P2", amount = 500,
+                      id = "withdraw|P2|500|0:0", timestamp = 0, scannedBy = "Me-Realm" },
                 },
             }
 


### PR DESCRIPTION
Spike on record creation, asking whether normalizing the money log's `"withdrawal"` to `"withdraw"` creates collisions, and whether it is cosmetic given that item and money records are shaped differently.

Doc-only by the packaged-file test: every file touched (`docs/`, `spec/`) is stripped by `.pkgmeta`, and `CHANGELOG.md` is untouched, so no version stamp and no tag. Same shape as #78.

## What the spike found

**Not cosmetic.** The differing shapes do not make the string cosmetic, because nothing downstream reads the shape before reading the type. Every consumer matches the stored string exactly and none accepts both spellings: player stats, daily summaries, six sites in ConsumptionView, both type dropdowns, and the filter equality test. An un-normalized record contributes 0 to every money total, matches no filter, and is deleted at day 30 by compaction with nothing folded into the summary first. That silent zeroing is the v0.4.1 bug the normalization was added to fix.

It also fails accessibility in all three channels at once, which is worth naming separately because triple encoding is a v1.0 gate. `GetTxTypeDisplay` resolves color by comparison, icon by table lookup and label by table lookup, so an unrecognized type falls to `NEUTRAL`, a nil icon, and the raw string as its own label. Color, shape and text degrade together.

**Collisions are real but narrow, and the normalization is not the cause.** Well-formed item and money ids cannot collide: `buildPrefix` gives items five pipe fields and money three, and a player name cannot contain a pipe. The reachable case is the one already tracked as #69, an item record that lost its `itemID` and falls into the money branch. The normalization widens that case rather than causing it, since before the rewrite the two type strings still differed. `deposit` was already shared, because both APIs emit it verbatim, so the root cause is the `itemID` fallthrough.

**One consequence the first pass missed.** `NormalizeRecordId` adopts the sender's id for whatever `idIndex[matchedKey]` returns, and `idIndex` is built across both arrays with no namespace tag. So a colliding incoming item record can overwrite a stored money record's `id`, `_occurrence` and `timestamp`, and then be counted as a duplicate and dropped: one event loses its identity, another is discarded. The shape check in #68 closes it, since a record that lost its `itemID` has neither `itemID` nor `amount` and is rejected at intake. Recorded because it sits in the receive path rather than in #68's stated subject, so its test list should cover it.

**Sync intake never normalizes**, so a `"withdrawal"` record from a peer would be stored verbatim. No such record exists or can arrive: zero across all 12,310 stored records, no tagged release ever shipped the un-normalized code (money landed in v0.2.0, the fix in v0.4.1, no tag between them, earliest tag v0.5.0-alpha), the concurrent money-tab-index bug in the same commit meant money never loaded for a guild with fewer than eight tabs, and the exact version match in `HandleHello` rules out a mixed-version peer. #68's enum check closes it by rejection, which is right because no legitimate sender of that string can exist.

**Un-normalizing is not worth holding open.** `"withdraw"` is in every stored money id, so reverting needs a migration, a wire-fixture update and a floor raise, and leaves a permanent bucket-hash mismatch meanwhile: bucket keys are parsed from the id's hour-slot suffix, so a type-only change moves nothing between buckets while changing every hash contribution, and the affected bucket re-syncs without converging.

## Changes

- `docs/DATA-MODEL.md`: two subsections in section 5, one on the pooled identity namespace and the `NormalizeRecordId` hazard, one on the type string and the normalization verdict. Two rows added to the tracking table, both pointing at #68.
- `spec/ledger_spec.lua`: a builder-level test asserting both the stored type and the resulting id, plus one that the other four API money types pass through untouched. Only the read path was pinned before.
- `spec/helpers.lua`: `makeMoneyTransaction`'s docblock listed the storage enum rather than the API enum, so `"withdrawal"` was missing from the one helper whose job is to model what the API returns. A test written from that signature would skip the normalization branch and pass without proving anything, which is the same omission that hid the original bug.
- `spec/sync_spec.lua`: three fixtures carried `type = "withdrawal"` on item records, a value items can never hold, plus a `subClassID` casing typo in one of them.

## Verification

Confirmed the new builder test is a real pin rather than a tautology: with the normalization line disabled it fails, alongside the two existing read-path tests, and passes with it restored.

`bash run_tests.sh` is 1427 successes / 0 failures. `bash run_tests.sh --lint` is 0 warnings / 0 errors across 27 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBU82puQujhBzrJ982hjoJ
