### PR TITLE
Pin the vendored library revisions

### DIFF
--- a/spec/fixtures/generate_wire_fixtures.lua
+++ b/spec/fixtures/generate_wire_fixtures.lua
@@ -99,12 +99,25 @@ local UPSTREAM = {
     ["AceSerializer-3.0.lua"] = "Libs/AceSerializer-3.0/AceSerializer-3.0.lua",
 }
 
+--- Collapse SVN keyword expansion and line endings before comparing.
+--
+-- Whether `$Id$` arrives expanded depends on how the checkout was made, not on
+-- the library's contents: the release workflow's fetch expands it to
+-- `$Id: AceSerializer-3.0.lua 1284 ... $` while the copies here carry the bare
+-- `$Id$`. Comparing raw bytes would report that as upstream drift on any machine
+-- whose Libs/ came from the packager, which is a false alarm about the one thing
+-- this check exists to catch. Same for CRLF, since Libs/ is fetched on whatever
+-- platform the developer is on.
+local function normalize(content)
+    return (content:gsub("%$Id[^%$]*%$", "$Id$"):gsub("\r\n", "\n"))
+end
+
 print("\n=== vendored libraries vs Libs/ ===")
 for vendored, upstream in pairs(UPSTREAM) do
     local theirs = readFile(upstream)
     if not theirs then
         print(("--  %s: no Libs/ tree here, nothing to compare"):format(vendored))
-    elseif readFile(Wire.VENDOR_DIR .. vendored) == theirs then
+    elseif normalize(readFile(Wire.VENDOR_DIR .. vendored)) == normalize(theirs) then
         print(("ok  %s matches %s"):format(vendored, upstream))
     else
         print(("!! %s differs from %s. Upstream has moved. Copy it over and run the "

--- a/spec/vendor/README.md
+++ b/spec/vendor/README.md
@@ -8,13 +8,25 @@ packager and nowhere else. CI checks out a tree with no `Libs/` at all.
 depends on are committed here instead. Nothing else in the suite uses them, and
 `.pkgmeta` strips `spec` from the packaged addon, so these are never shipped.
 
-| File | Upstream | License |
-|---|---|---|
-| `LibStub.lua` | https://repos.wowace.com/wow/libstub/trunk | Public domain |
-| `AceSerializer-3.0.lua` | https://repos.wowace.com/wow/ace3/trunk/AceSerializer-3.0 | Ace3 (permissive) |
+| File | Upstream | Revision | Library version | License |
+|---|---|---|---|---|
+| `LibStub.lua` | https://repos.wowace.com/wow/libstub/trunk | r103, 2014-10-16 | LibStub minor 2 | Public domain |
+| `AceSerializer-3.0.lua` | https://repos.wowace.com/wow/ace3/trunk/AceSerializer-3.0 | r1284, 2022-09-25 | AceSerializer-3.0 minor 5 | Ace3 (permissive) |
 
 Both are verbatim copies. Do not edit them. If a test needs different behavior,
 the test is wrong.
+
+Neither has moved in a long time, which is the main reason pinning a copy is a
+cheap thing to do here: AceSerializer's wire format has been at minor 5 since
+2022 and LibStub since 2014.
+
+The AceSerializer revision is not readable from the file itself. Its header
+carries an unexpanded `-- @release $Id$`, because the checkout these copies came
+from did not have SVN keyword substitution on. The r1284 figure comes from the
+packaged v0.36.1 zip, where the release workflow's own fetch **did** expand it to
+`$Id: AceSerializer-3.0.lua 1284 2022-09-25 09:15:30Z nevcairiel $`. That is the
+same file, so if a refresh needs to know what it is replacing, download a release
+zip and read the header there.
 
 **LibDeflate is deliberately absent.** The harness serializes but does not
 compress. Compression is a pure, byte-exact codec that this addon neither
@@ -31,3 +43,9 @@ when `Libs/` is present, and reports any difference. So the test run is
 deterministic everywhere, and a developer with the real libraries still finds out
 if upstream has moved. Refresh by copying the files over and running the full
 suite: a real behavior change shows up as frozen fixtures that no longer decode.
+
+That check normalizes `$Id$` expansion and line endings before comparing. Both
+vary with how a checkout was made rather than with what the library does, so
+comparing them raw would cry drift on any machine whose `Libs/` came from the
+packager, which is exactly the alarm this check needs to be trusted not to
+raise falsely.


### PR DESCRIPTION
Doc-only follow-up to #80. Every file touched is under `spec/`, which `.pkgmeta` strips, and `CHANGELOG.md` is untouched, so no version stamp and no tag.

## Provenance

`spec/vendor/README.md` recorded where the two libraries came from but not which revision, so a future refresh had nothing to check against. Now pinned: LibStub r103 (2014-10-16, minor 2), AceSerializer r1284 (2022-09-25, minor 5). Neither has moved in years, which is most of why pinning a copy is cheap here rather than a maintenance burden.

AceSerializer's revision is not readable from the file itself: its header carries an unexpanded `-- @release $Id$`, because the checkout these copies came from did not have SVN keyword substitution enabled. The number comes from the packaged v0.36.1 zip, where the release workflow's own fetch **did** expand it to `$Id: AceSerializer-3.0.lua 1284 2022-09-25 09:15:30Z nevcairiel $`. The README records that route so the next person can find it the same way.

## A false positive in the drift check, found the same way

Comparing the v0.36.1 zip against the vendored copy showed a 61-byte difference, which looked exactly like the upstream drift `generate_wire_fixtures.lua` exists to catch. It was not: 287 lines either way, differing only in that comment.

But the check itself diffed raw bytes, and a `Libs/` tree fetched by the packager carries the expanded form. So on any machine where the packager had run, the check would have reported drift on a file that is byte-identical apart from a comment. A drift alarm that fires on a non-difference is one people learn to ignore, which would have quietly cost the check its whole value.

It now normalizes `$Id$` expansion and line endings before comparing. Both vary with how a checkout was made rather than with what the library does.

## Verification

- Normalization does its job: the check reports `ok` when `Libs/` is replaced with the actual expanded file extracted from the published v0.36.1 zip. Raw bytes would have failed there.
- It is not over-normalized: changing AceSerializer's `MINOR` from 5 to 6 in `Libs/` still reports drift and exits non-zero.
- `bash run_tests.sh`: 1513 passing. `bash run_tests.sh --lint`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBU82puQujhBzrJ982hjoJ
