### PR TITLE
Stop advertising compaction that has never run

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,7 +19,7 @@ The May 2026 honest-status sweep discovered that `UI/Accessibility.lua` had defi
 - **src/Categories.lua** — Item classification via WoW classID/subclassID
 - **src/Dedup.lua** — Deduplication engine (occurrence-based hashing, fuzzy matching, event count metadata, count-based cleanup)
 - **src/Ledger.lua** — Transaction recording from GetGuildBankTransaction API
-- **src/Storage.lua** — Tiered storage, compaction (30d daily, 90d weekly), pruning
+- **src/Storage.lua** — Tiered storage, compaction (30d daily, 90d weekly), pruning. **None of it has ever run.** `RunCompaction` opens with `if self.scanInProgress then return end` and its only caller fires two `C_Timer.After(0)` levels inside the transaction-scan callback, while the async slot scan is still going, so the guard wins on every bank open. Full raw history is intact and the range filters have been answering correctly all along. Being retired rather than repaired (issue #62): compaction is incompatible with sync, and this file is also the only one in the addon calling `os.date`/`os.time`, which WoW's Lua sandbox does not provide. Do not read the code here as a description of runtime behaviour
 - **src/Fingerprint.lua** — Dataset fingerprinting (djb2 hash, XOR aggregation, 6-hour bucket hashes)
 - **src/ItemCache.lua** — Lazy async item info cache (GetItemInfo + GET_ITEM_INFO_RECEIVED for synced records)
 - **src/Sync.lua** — Guild-wide sync via AceComm (HELLO/SYNC_REQUEST/SYNC_DATA/ACK/BUSY/MANIFEST/LAYOUT_REQUEST/LAYOUT_DATA protocol, epidemic gossip propagation, concurrent send+receive, smart peer selection, hash-gated HELLO reply suppression, fingerprint-based delta sync, pending peers queue, NACK backoff, combat/zone guards, bidirectional sync, jitter, bank-layout advertise-and-pull)

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ Persistent guild bank transaction logging for World of Warcraft. WoW's built-in 
 - **Deduplication** — Occurrence-based hashing with event count metadata prevents duplicate records across multiple scanners
 - **Money tracking** — Records deposits, withdrawals, repairs, tab purchases
 - **Per-player statistics** — Tracks deposit/withdrawal counts, money totals, first/last seen timestamps
-- **Tiered storage** — Full records (0-30d), daily summaries (30-90d), weekly summaries (90d+)
-- **Automatic compaction** — Old data compressed into summaries on bank open
+- **Full history, kept indefinitely** — Every transaction stays a complete record. `src/Storage.lua` still contains a tiered-storage and compaction layer (full records 0-30d, daily summaries 30-90d, weekly beyond), but it has never once run: its entry point is guarded on `scanInProgress`, and the only caller fires while the scan is still going. It is being retired rather than repaired (issue #62), because compaction is incompatible with sync: a peer that compacted would drop to a 30-day fingerprint, every other peer would read it as far behind and push the records back
 - **UI window** — Tabbed interface with Transactions, Gold Log, Consumption, Sort, Layout, Restock, Sync, Changelog, and About views, opened via `/gbl` or minimap button
 - **Transaction list** — Scrolling list with sortable columns: Timestamp, Player, Action, Item, Count, Category, Tab
 - **Filter bar** — Search by player/item, filter by date range, category, transaction type, tab, with reset button
@@ -37,7 +36,7 @@ These items block the v1.0 release:
 
 - Accessibility audit and keyboard-nav completion: wire `RegisterFocusable` into every AceGUI widget, hook Tab/Shift+Tab via a key handler, verify focus indicators on every tab, screen-reader audit, palette validation against WCAG AAA contrast targets
 - Sync rate limiting (per-peer bandwidth budgeting)
-- Performance audit (SavedVariables size, compaction verification, UI debouncing)
+- Performance audit (SavedVariables size, UI debouncing). Compaction verification came off this list when compaction itself was retired (#62)
 - Community feedback iteration
 
 ### Planned (Post-1.0)

--- a/docs/CURSEFORGE-DESCRIPTION.md
+++ b/docs/CURSEFORGE-DESCRIPTION.md
@@ -10,7 +10,7 @@ WoW's guild bank log only keeps 25 entries per tab. In an active guild, that rol
 - Records every deposit, withdrawal, move, repair, and gold transaction
 - Categorizes items (flasks, herbs, ore, gems, weapons, armor, and 30+ categories)
 - Deduplicates across multiple scanners so nothing is double-counted
-- Automatically compacts old data to keep SavedVariables small (full records → daily summaries after 30d → weekly after 90d)
+- Keeps every transaction in full, forever. Nothing is ever summarized away, so per-player consumption stays answerable across the guild's whole history
 
 ## Guild-Wide Sync
 
@@ -66,7 +66,7 @@ Settings sync to all guild members automatically.
 
 **Status**: Beta. Recording and dedup are mature. Sync, sort, and UI are in active guild use with known improvements queued. Accessibility ships with palettes, contrast, triple encoding, and font scaling, but keyboard navigation is partial pending a v1.0 audit pass.
 
-**Before v1.0**: complete accessibility audit and keyboard-nav wiring across all UI widgets, sync rate limiting, performance audit (SavedVariables size, compaction verification, UI debouncing).
+**Before v1.0**: complete accessibility audit and keyboard-nav wiring across all UI widgets, sync rate limiting, performance audit (SavedVariables size, UI debouncing).
 
 **Planned post-1.0**: analytics dashboard, raid team management, alt linking, stock tab (passive inventory view), stock alerts, Guild Bank Sort integration, CSV/Discord/BBCode export.
 


### PR DESCRIPTION
Toward #62. Documentation only; the code removal stays with that issue.

The CurseForge page told users the addon "automatically compacts old data to keep SavedVariables small (full records → daily summaries after 30d → weekly after 90d)". It does not, and never has. #62 established that `dailySummaries` appears **zero times** in a 7.3 MB live SavedVariables holding about 12,000 records: `RunCompaction` opens with `if self.scanInProgress then return end`, and its only caller fires two `C_Timer.After(0)` levels inside the transaction-scan callback while the async slot scan is still running, so the guard wins on every bank open.

The README carried the same claim twice, once as a feature bullet and once as a storage-tier description.

## What replaces it

The truth is a better claim than the false one. Every transaction is kept in full, indefinitely, which is exactly what makes per-player consumption answerable across a guild's whole history. Compaction is being retired rather than repaired because keeping everything is the right behaviour and because compaction is incompatible with sync: a peer that compacted would drop to a 30-day fingerprint, every other peer would read it as far behind and push the records back, and the next bank open would compact them again.

"Compaction verification" comes off the pre-1.0 list in both the README and the CurseForge description. `docs/ROADMAP.md` had already dropped it, which is how the drift became visible.

`CLAUDE.md`'s architecture line now states the module is dead code instead of describing it as though it runs. Reading that entry as behaviour is how the claim survived this long.

## No version, no tag, no CHANGELOG entry

Every file here (`README.md`, `docs/`, `CLAUDE.md`) is stripped by `.pkgmeta`, so the packaged addon is byte-identical. A CHANGELOG entry would ship it, because the packager copies the changelog back in regardless of the ignore list, and that would bill the guild a version for a documentation correction.

Worth stating since v0.37.0 has just gone out: the floor makes releases cheap, but not free, and this one buys users nothing they can see in-game.

## Verification

Suite green (1564). `grep -i compact` over `README.md` and `docs/CURSEFORGE-DESCRIPTION.md` returns only the two honest mentions that explain the module never runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01YBU82puQujhBzrJ982hjoJ