### PR TITLE
Correct the spec comment the jitter removal overstated

### DIFF
--- a/spec/sync_spec.lua
+++ b/spec/sync_spec.lua
@@ -3762,9 +3762,12 @@ describe("Sync", function()
 
             GBL:HandleHello("OfficerB", hello())
 
-            -- Counting timers used to be the discriminator here. It is not
-            -- one any more: the happy path schedules nothing either, so that
-            -- assertion would hold with the check deleted.
+            -- Counting timers used to be the discriminator here. Its stated
+            -- reason died with the jitter timer, and the power it kept was
+            -- incidental: a deleted busy check would still bump the count,
+            -- but only via the receive timeout RequestSync arms for the
+            -- request it should not be making. Asserting on the wire pins
+            -- the contract for a reason that survives timer rearrangement.
             assert.equals(0, countSent("SYNC_REQUEST", "OfficerB"))
             local logged = false
             for _, entry in ipairs(GBL:GetAuditTrail()) do


### PR DESCRIPTION
Follow-up to #106. One clause in the busy fast-path test's comment is false: it says the old timer-count assertion would have held with the busy check deleted because "the happy path schedules nothing either". RequestSync arms the receive timeout synchronously (ScheduleReceiveTimeout, src/Sync.lua:1584), so the count would still have bumped and the old assertion would still have tripped, only incidentally and with a failure message naming a timer that no longer exists.

Comment-only change to a spec file, which the packager strips, so no version and no tag. The countSent assertion itself stands as shipped; PR #106's body carries the same correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS22QBV45AbZKfH6XpFJCb
