### PR TITLE
Put the Sync tab under the area label its files actually belong to

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -18,6 +18,12 @@
 #          advisory; the issue carries the authoritative one. Fix by hand what
 #          the globs get wrong.
 #
+# UI/SyncStatus.lua is area: ui, not area: sync, and the same for its spec. The
+# area labels are defined by file, not by subject: area: sync is Sync.lua and
+# Fingerprint.lua (the protocol), area: ui is everything under UI/ (the frame
+# and tab plumbing). The Sync tab is a tab. #89 and #98 were backfilled that
+# way, so the rule here has to match or the record and the automation disagree.
+#
 # src/Core.lua, src/Logger.lua and src/ItemCache.lua are deliberately unmapped.
 # All three are cross-cutting, so a PR touching them almost always touches the
 # subsystem it is actually about, and that is where the area comes from. A
@@ -49,14 +55,12 @@
           - 'src/Sync.lua'
           - 'src/Fingerprint.lua'
           - 'src/AuditCapture.lua'
-          - 'UI/SyncStatus.lua'
           - 'spec/sync_spec.lua'
           - 'spec/fingerprint_spec.lua'
           - 'spec/auditcapture_spec.lua'
           - 'spec/wire_contract_spec.lua'
           - 'spec/wire_helpers.lua'
           - 'spec/fixtures/wire/**'
-          - 'spec/ui/syncstatus_tag_spec.lua'
           - 'docs/sync-logs/**'
           - 'docs/sync-bucket-analysis.md'
           - 'docs/PLAN-audit-log-upload.md'
@@ -122,9 +126,11 @@
           - 'UI/FilterBar.lua'
           - 'UI/ChangelogView.lua'
           - 'UI/AboutView.lua'
+          - 'UI/SyncStatus.lua'
           - 'src/ChatFilters.lua'
           - 'spec/about_spec.lua'
           - 'spec/chatfilters_spec.lua'
+          - 'spec/ui/syncstatus_tag_spec.lua'
           - 'spec/ui/changelog_spec.lua'
           - 'spec/ui/consumption_spec.lua'
           - 'spec/ui/filter_spec.lua'


### PR DESCRIPTION
Follow-up to #111, and the first live test of the labeler it added.

## The mismatch

The `area:` labels are defined by file, not by subject: `area: sync` is `src/Sync.lua` and `src/Fingerprint.lua` (the protocol), `area: ui` is everything under `UI/` (frame and tab plumbing). The backfill applied that rule and gave #89 and #98 `area: ui`. The labeler config did not: it mapped `UI/SyncStatus.lua` and `spec/ui/syncstatus_tag_spec.lua` to `area: sync`, so every future Sync tab PR would have been labelled against the record it is supposed to extend.

Moved both to `area: ui`, with the reasoning in a comment so the next person does not move them back.

Separately, PRs #102 and #104 now carry `area: accessibility`. The config already implies it (both touch `spec/ascii_strings_spec.lua`, which maps there) and the backfill missed it. The ASCII rule exists because a symbol that does not draw leaves a row whose state is carried by colour alone, which is the triple-encoding failure the accessibility rule prevents. Both belong in the query the v1.0 accessibility gate will run.

## Acceptance test for #111

This PR is the one the labeler can actually act on, since #111's own run came off a base branch that did not have the workflow yet. Expect `type: chore` from the branch prefix and `area: repo` from the `.github/**` glob, applied automatically with no token error in the run log.

## Version

No version, no tag, no CHANGELOG. One file changed, under `.github/`, stripped from the packaged zip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PS22QBV45AbZKfH6XpFJCb
