### PR TITLE
Install the CI Lua toolchain from apt instead of building from lua.org

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,18 +19,25 @@ jobs:
             exit 1
           fi
 
-      - name: Set up Lua 5.1
-        uses: leafo/gh-actions-lua@v10
-        with:
-          luaVersion: "5.1"
+      # Installed from the runner's own apt mirrors rather than built from the
+      # lua.org tarball. Building from source put the merge gate behind one
+      # third-party website with no mirror: when lua.org was unreachable on
+      # 2026-08-07 every run failed before reaching busted, and the build cache
+      # that would have absorbed it was answering 400. Lua 5.1 is frozen, so
+      # tracking the distribution package carries no version-drift risk.
+      - name: Set up Lua 5.1 and LuaRocks
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks
 
-      - name: Set up LuaRocks
-        uses: leafo/gh-actions-luarocks@v4
-
+      # luarocks-5.1 is the versioned entry point the distribution package ships
+      # alongside /etc/luarocks/config-5.1.lua, which already points at Lua 5.1's
+      # headers under /usr/include/lua5.1. Plain `luarocks` would build against
+      # the default interpreter instead.
       - name: Install busted and luacheck
         run: |
-          luarocks install busted
-          luarocks install luacheck
+          sudo luarocks-5.1 install busted
+          sudo luarocks-5.1 install luacheck
 
       - name: Run tests
         run: busted --verbose

--- a/spec/toolchain_spec.lua
+++ b/spec/toolchain_spec.lua
@@ -1,0 +1,23 @@
+------------------------------------------------------------------------
+-- Toolchain invariant: the suite runs under Lua 5.1
+------------------------------------------------------------------------
+-- The addon lives inside WoW's Lua 5.1 sandbox, so a suite executed by a
+-- later interpreter accepts syntax and semantics the game rejects and then
+-- reports green over code that breaks in-game.
+--
+-- This is a live check rather than a note in a doc because the interpreter is
+-- chosen outside the repository: CI installs it from the distribution's
+-- packages and every developer machine supplies its own. In CI the versioned
+-- `luarocks-5.1` is what binds busted to Lua 5.1; plain `luarocks` would build
+-- it against whichever interpreter the distribution defaults to, which is a
+-- one-word edit away in .github/workflows/ci.yml and would otherwise change
+-- nothing visible.
+--
+-- LuaJIT reports "Lua 5.1" here too, which is correct: that is what the game
+-- ships.
+
+describe("toolchain", function()
+    it("runs the suite under Lua 5.1", function()
+        assert.equal("Lua 5.1", _VERSION)
+    end)
+end)


### PR DESCRIPTION
Closes #51.

`test-and-lint` is a required check and it built Lua 5.1 from the source tarball at lua.org on every run, so the merge gate sat behind one third-party website with no mirror and no SLA. Both halves of the issue go away by not building Lua at all.

## What changed

`leafo/gh-actions-lua@v10` and `leafo/gh-actions-luarocks@v4` are replaced by the distribution's own packages:

```yaml
sudo apt-get install -y lua5.1 liblua5.1-0-dev luarocks
sudo luarocks-5.1 install busted
sudo luarocks-5.1 install luacheck
```

That removes lua.org from the critical path, and with it the build cache whose 400s were the second half of the issue: there is no longer a source build to cache. Two third-party actions come off the workflow at the same time.

The Lua action was checked for a way to keep it: `luaVersion`, `luaCompileFlags` and `buildCache` are its only inputs, with no mirror or custom-URL option, so the tarball fetch could not be redirected without forking it.

## Why apt is safe here

Ubuntu's mirrors are Azure-hosted and effectively inside the runner's own availability envelope, which is the argument the issue already made. Lua 5.1 is frozen, so there is no version-drift risk in tracking a distribution package: noble ships 5.1.5, which is the same release the action was compiling.

The versioned `luarocks-5.1` entry point is the part worth not undoing. The distribution's luarocks ships `/etc/luarocks/config-5.1.lua` pointing at the 5.1 headers under `/usr/include/lua5.1`, which is exactly the multi-version layout Debian maintains it for. Plain `luarocks` would build busted against whichever interpreter the distribution defaults to. Both the workflow comment and the new spec say so, because it is a one-word edit away.

## Test

`spec/toolchain_spec.lua` asserts `_VERSION == "Lua 5.1"`.

The interpreter is chosen outside the repository (CI installs it, each developer machine supplies its own), so until now nothing in the suite noticed which one it ran under. A suite executed by a later interpreter accepts syntax and semantics the game rejects and reports green over code that breaks in-game, and that failure is silent, which is the class this PR could otherwise introduce. LuaJIT reports `Lua 5.1` here too, which is correct: that is what the game ships.

Confirmed as a real pin rather than a tautology by mutating the expected value to `Lua 5.4` and watching it fail on the real `_VERSION`, then reverting.

Local run: 1660 successes / 0 failures / 0 errors, luacheck 0 warnings / 0 errors in 27 files.

## Verification

The issue asks for a green `test-and-lint` with no request to `www.lua.org` anywhere in the log. This workflow triggers on `pull_request`, so this PR's own run is that proof, and nothing in the file references lua.org any more.

## No version, no tag

Both changed paths are stripped from the packaged zip (`spec` by `.pkgmeta`'s ignore list, `.github` by the packager), so the addon is byte-identical and there is nothing to release. No CHANGELOG entry either: a CI config change with no effect on how the addon is built or how contributors run the suite locally, which `bash run_tests.sh` still does unchanged.

## Not included

The issue's "Why nobody noticed" section is untouched: the workflow still runs only on `pull_request` and `push: main`, so a five-week gap between runs can still hide toolchain rot until the next PR needs it. That is a separate concern from the install path and worth its own issue rather than riding this one.
